### PR TITLE
Fix HeartbeatWorker build issue completely

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -32,7 +32,6 @@
     "@tanstack/react-query": "^5.69.0",
     "@types/leaflet": "^1.9.18",
     "@types/recharts": "^1.8.29",
-    "@usedapp/core": "^1.2.16",
     "@wagmi/connectors": "^2.0.0",
     "axios": "^1.10.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
- Remove unused @usedapp/core dependency causing ethers version conflicts
- Clean reinstall of all dependencies with --legacy-peer-deps
- Confirmed build now works successfully without HeartbeatWorker errors
- Next.js config properly ignoring HeartbeatWorker files
