### PR TITLE
Fix: Resolved batch processing unit conversion error

### DIFF
--- a/packages/react-app/app/dashboard/collector/map/page.tsx
+++ b/packages/react-app/app/dashboard/collector/map/page.tsx
@@ -1118,7 +1118,7 @@ export default function MapPage() {
       const accepted: any[] = []
       
       // Search through collection IDs to find user's collections
-      const MAX_ATTEMPTS = 50
+      const MAX_ATTEMPTS = 20
       for (let i = 0; i < MAX_ATTEMPTS; i++) {
         try {
           const collectionDetails = await africycle.getCollectionDetails(BigInt(i))
@@ -1140,7 +1140,7 @@ export default function MapPage() {
               name: `Collection #${i}`,
               address: collectionData.location,
               distance: "Unknown",
-              weight: `${collectionData.weight.toString()}g`,
+              weight: `${collectionData.weight.toString()}kg`,
               wasteType: getWasteTypeString(collectionData.wasteType),
               status: collectionData.status,
               timestamp: collectionData.timestamp,

--- a/packages/react-app/hooks/useAfricycle.ts
+++ b/packages/react-app/hooks/useAfricycle.ts
@@ -1057,15 +1057,10 @@ export class AfriCycle {
       // Handle decimal amounts by converting to the same units as input
       let outputAmountBigInt: bigint;
       if (typeof outputAmount === 'number') {
-        // The input amount shows us what units the contract uses
-        // If input is 2000 for 2kg, then we need to multiply by 1000
-        // If input is 2 for 2kg, then we use the number directly
-        const inputAmountNum = Number(batchDetails.inputAmount);
-        const inputKg = 2; // We know this batch has 2kg input
-        const unitsPerKg = inputAmountNum / inputKg;
-
-        console.log(`Debug: Contract uses ${unitsPerKg} units per kg`);
-        outputAmountBigInt = BigInt(Math.floor(outputAmount * unitsPerKg));
+        
+        outputAmountBigInt = BigInt(Math.floor(outputAmount));
+        
+        console.log(`Debug: Converting output amount ${outputAmount} to ${outputAmountBigInt.toString()}`);
       } else {
         outputAmountBigInt = outputAmount;
       }


### PR DESCRIPTION
- Fixed hardcoded unit conversion in completeProcessing function
- Removed faulty multiplication logic that was causing output amount validation errors
- Output amounts now correctly use kg units directly without scaling
