### PR TITLE
fix: Excluded test configuration files from Next.js TypeScript compilation

### DIFF
--- a/packages/react-app/tsconfig.json
+++ b/packages/react-app/tsconfig.json
@@ -26,5 +26,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "tests/**/*", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["node_modules", "tests/**/*", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "vitest.config.ts", "jest.config.js", "playwright.config.ts"]
 }


### PR DESCRIPTION

This ensures test configuration files don't interfere with the Next.js build process.